### PR TITLE
chore: bump `faker` to `5.1.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,9 +44,9 @@
       }
     },
     "@types/faker": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@types/faker/-/faker-4.1.12.tgz",
-      "integrity": "sha512-0MEyzJrLLs1WaOCx9ULK6FzdCSj2EuxdSP9kvuxxdBEGujZYUOZ4vkPXdgu3dhyg/pOdn7VCatelYX7k0YShlA==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@types/faker/-/faker-5.1.4.tgz",
+      "integrity": "sha512-ZK+Bmi5GcWSLe8TQDOj9+K5KImV/41Ydm7Fs3IbtAA11l1MVK0Dlo16KTni5cGZISxGiCaWE+uB9gznWT2GUgw==",
       "dev": true
     },
     "@types/node": {
@@ -244,9 +244,9 @@
       }
     },
     "faker": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
-      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-5.1.0.tgz",
+      "integrity": "sha512-RrWKFSSA/aNLP0g3o2WW1Zez7/MnMr7xkiZmoCfAGZmdkDQZ6l2KtuXHN5XjdvpRjDl8+3vf+Rrtl06Z352+Mw=="
     },
     "fast-safe-stringify": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
   "author": "Edward Anthony <edwardanthony@fastmail.com>",
   "license": "MIT",
   "dependencies": {
-    "faker": "^4.1.0"
+    "faker": "^5.1.0"
   },
   "devDependencies": {
     "@nestjs/common": "^7.3.1",
     "@nestjs/core": "^7.3.1",
-    "@types/faker": "^4.1.12",
+    "@types/faker": "^5.1.4",
     "@types/node": "^14.0.14",
     "reflect-metadata": "*",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
As mentioned, https://github.com/edwardanthony/nestjs-seeder/issues/8.