### PR TITLE
bump @faker-js to v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nestjs-seeder",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nestjs-seeder",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "devDependencies": {
         "@nestjs/common": "^9.4.0",
@@ -18,13 +18,13 @@
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "@faker-js/faker": "^8.0.0"
+        "@faker-js/faker": "^9.0.0"
       }
     },
     "node_modules/@faker-js/faker": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.0.2.tgz",
-      "integrity": "sha512-Uo3pGspElQW91PCvKSIAXoEgAUlRnH29sX2/p89kg7sP1m2PzCufHINd0FhTXQf6DYGiUlVncdSPa2F9wxed2A==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.0.2.tgz",
+      "integrity": "sha512-nI/FP30ZGXb+UaR7yXawVTH40NVKXPIx0tA3GKjkKLjorqBoMAeq4iSEacl8mJmpVhOCDa0vYHwYDmOOcFMrYw==",
       "funding": [
         {
           "type": "opencollective",
@@ -33,8 +33,8 @@
       ],
       "peer": true,
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
-        "npm": ">=6.14.13"
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -788,9 +788,9 @@
   },
   "dependencies": {
     "@faker-js/faker": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.0.2.tgz",
-      "integrity": "sha512-Uo3pGspElQW91PCvKSIAXoEgAUlRnH29sX2/p89kg7sP1m2PzCufHINd0FhTXQf6DYGiUlVncdSPa2F9wxed2A==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.0.2.tgz",
+      "integrity": "sha512-nI/FP30ZGXb+UaR7yXawVTH40NVKXPIx0tA3GKjkKLjorqBoMAeq4iSEacl8mJmpVhOCDa0vYHwYDmOOcFMrYw==",
       "peer": true
     },
     "@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "author": "Edward Anthony <edwardanthony@fastmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "@faker-js/faker": "^8.0.0"
+    "@faker-js/faker": "^9.0.0"
   },
   "devDependencies": {
     "@nestjs/common": "^9.4.0",


### PR DESCRIPTION
Now supports version 9 of @faker-js as peerDependencies.